### PR TITLE
Fixed unit tests to run on Windows

### DIFF
--- a/content_store.go
+++ b/content_store.go
@@ -29,8 +29,8 @@ func NewContentStore(base string) (*ContentStore, error) {
 }
 
 // Get takes a Meta object and retreives the content from the store, returning
-// it as an io.Reader. If fromByte > 0, the reader starts from that byte
-func (s *ContentStore) Get(meta *MetaObject, fromByte int64) (io.Reader, error) {
+// it as an io.ReaderCloser. If fromByte > 0, the reader starts from that byte
+func (s *ContentStore) Get(meta *MetaObject, fromByte int64) (io.ReadCloser, error) {
 	path := filepath.Join(s.basePath, transformKey(meta.Oid))
 
 	f, err := os.Open(path)

--- a/content_store_test.go
+++ b/content_store_test.go
@@ -10,7 +10,7 @@ import (
 
 var contentStore *ContentStore
 
-func TestContenStorePut(t *testing.T) {
+func TestContentStorePut(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -31,7 +31,7 @@ func TestContenStorePut(t *testing.T) {
 	}
 }
 
-func TestContenStorePutHashMismatch(t *testing.T) {
+func TestContentStorePutHashMismatch(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -52,7 +52,7 @@ func TestContenStorePutHashMismatch(t *testing.T) {
 	}
 }
 
-func TestContenStorePutSizeMismatch(t *testing.T) {
+func TestContentStorePutSizeMismatch(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -73,7 +73,7 @@ func TestContenStorePutSizeMismatch(t *testing.T) {
 	}
 }
 
-func TestContenStoreGet(t *testing.T) {
+func TestContentStoreGet(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -91,6 +91,8 @@ func TestContenStoreGet(t *testing.T) {
 	r, err := contentStore.Get(m, 0)
 	if err != nil {
 		t.Fatalf("expected get to succeed, got: %s", err)
+	} else {
+		defer r.Close()
 	}
 
 	by, _ := ioutil.ReadAll(r)
@@ -99,7 +101,7 @@ func TestContenStoreGet(t *testing.T) {
 	}
 }
 
-func TestContenStoreGetWithRange(t *testing.T) {
+func TestContentStoreGetWithRange(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -117,6 +119,8 @@ func TestContenStoreGetWithRange(t *testing.T) {
 	r, err := contentStore.Get(m, 5)
 	if err != nil {
 		t.Fatalf("expected get to succeed, got: %s", err)
+	} else {
+		defer r.Close()
 	}
 
 	by, _ := ioutil.ReadAll(r)
@@ -135,7 +139,7 @@ func TestContenStoreGetNonExisting(t *testing.T) {
 	}
 }
 
-func TestContenStoreExists(t *testing.T) {
+func TestContentStoreExists(t *testing.T) {
 	setup()
 	defer teardown()
 

--- a/meta_store_test.go
+++ b/meta_store_test.go
@@ -107,5 +107,6 @@ func setupMeta() {
 }
 
 func teardownMeta() {
+	metaStoreTest.Close()
 	os.RemoveAll("test-meta-store.db")
 }

--- a/mgmt.go
+++ b/mgmt.go
@@ -123,6 +123,7 @@ func (a *App) objectsRawHandler(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, r, 404)
 		return
 	}
+	defer content.Close()
 
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s;", vars["oid"]))

--- a/server.go
+++ b/server.go
@@ -200,6 +200,7 @@ func (a *App) GetContentHandler(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, r, 404)
 		return
 	}
+	defer content.Close()
 
 	w.WriteHeader(statusCode)
 	io.Copy(w, content)

--- a/server_test.go
+++ b/server_test.go
@@ -26,7 +26,7 @@ func TestGetAuthed(t *testing.T) {
 	}
 
 	if res.StatusCode != 200 {
-		t.Fatalf("expected status 302, got %d", res.StatusCode)
+		t.Fatalf("expected status 200, got %d", res.StatusCode)
 	}
 
 	by, err := ioutil.ReadAll(res.Body)
@@ -280,6 +280,8 @@ func TestPut(t *testing.T) {
 	r, err := testContentStore.Get(&MetaObject{Oid: contentOid}, 0)
 	if err != nil {
 		t.Fatalf("error retreiving from content store: %s", err)
+	} else {
+		defer r.Close()
 	}
 	c, err := ioutil.ReadAll(r)
 	if err != nil {


### PR DESCRIPTION
I was unable to get the unit tests to run properly on Windows. The issue was that temporary content created by the unit tests was not getting properly released. This pull request updates the `ContentStore.Get()` method to return an `io.ReadCloser` instead of an `io.Reader` and closes resources when appropriate so that the unit tests now function on Windows. Also, I fixed a few typos I found along the way.
