### PR TITLE
Return *os.File from ContentStore.Get, close handle after usage

### DIFF
--- a/content_store.go
+++ b/content_store.go
@@ -30,7 +30,7 @@ func NewContentStore(base string) (*ContentStore, error) {
 
 // Get takes a Meta object and retreives the content from the store, returning
 // it as an io.Reader. If fromByte > 0, the reader starts from that byte
-func (s *ContentStore) Get(meta *MetaObject, fromByte int64) (io.Reader, error) {
+func (s *ContentStore) Get(meta *MetaObject, fromByte int64) (*os.File, error) {
 	path := filepath.Join(s.basePath, transformKey(meta.Oid))
 
 	f, err := os.Open(path)

--- a/content_store_test.go
+++ b/content_store_test.go
@@ -97,6 +97,8 @@ func TestContenStoreGet(t *testing.T) {
 	if string(by) != "test content" {
 		t.Fatalf("expected to read content, got: %s", string(by))
 	}
+
+	r.Close()
 }
 
 func TestContenStoreGetWithRange(t *testing.T) {
@@ -123,16 +125,20 @@ func TestContenStoreGetWithRange(t *testing.T) {
 	if string(by) != "content" {
 		t.Fatalf("expected to read content, got: %s", string(by))
 	}
+
+	r.Close()
 }
 
 func TestContenStoreGetNonExisting(t *testing.T) {
 	setup()
 	defer teardown()
 
-	_, err := contentStore.Get(&MetaObject{Oid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, 0)
+	f, err := contentStore.Get(&MetaObject{Oid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, 0)
 	if err == nil {
 		t.Fatalf("expected to get an error, but content existed")
 	}
+
+	f.Close()
 }
 
 func TestContenStoreExists(t *testing.T) {

--- a/mgmt.go
+++ b/mgmt.go
@@ -129,6 +129,7 @@ func (a *App) objectsRawHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Transfer-Encoding", "binary")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", meta.Size))
 	io.Copy(w, content)
+	content.Close()
 }
 
 func (a *App) usersHandler(w http.ResponseWriter, r *http.Request) {

--- a/server.go
+++ b/server.go
@@ -204,6 +204,7 @@ func (a *App) GetContentHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(statusCode)
 	io.Copy(w, content)
 	logRequest(r, statusCode)
+	content.Close()
 }
 
 // GetMetaHandler retrieves metadata about the object

--- a/server_test.go
+++ b/server_test.go
@@ -288,6 +288,7 @@ func TestPut(t *testing.T) {
 	if string(c) != content {
 		t.Fatalf("expected content, got `%s`", string(c))
 	}
+	r.Close()
 }
 
 func TestMediaTypesRequired(t *testing.T) {


### PR DESCRIPTION
In the current master, the file handle is never properly closed. This PR lets the ContentStore return a proper *os.File handle, making it possible to close it after usage.