### PR TITLE
Locks Verification Fix

### DIFF
--- a/server.go
+++ b/server.go
@@ -414,11 +414,17 @@ func (a *App) LocksVerifyHandler(w http.ResponseWriter, r *http.Request) {
 		enc.Encode(&VerifiableLockList{Message: err.Error()})
 		return
 	}
+	
+	// Limit is optional
+	limit := reqBody.Limit
+	if limit == 0 {
+		limit = 100
+	}
 
 	ll := &VerifiableLockList{}
 	locks, nextCursor, err := a.metaStore.FilteredLocks(repo, "",
 		reqBody.Cursor,
-		strconv.Itoa(reqBody.Limit))
+		strconv.Itoa(limit))
 	if err != nil {
 		ll.Message = err.Error()
 	} else {


### PR DESCRIPTION
According to https://github.com/git-lfs/git-lfs/blob/master/docs/api/locking.md "limit" is optional
- Git LFS 2.3.4 client doesn't set "limit" to any value. So endless loop happens.
- It's common practice to have default value for "limit"