### PR TITLE
Re-added the copy of the auth-field to the response.

### DIFF
--- a/server.go
+++ b/server.go
@@ -24,6 +24,7 @@ type RequestVars struct {
 	User     string
 	Password string
 	Repo     string
+	Authorization string
 }
 
 type BatchVars struct {
@@ -551,6 +552,11 @@ func (a *App) Represent(rv *RequestVars, meta *MetaObject, download, upload, use
 
 	header := make(map[string]string)
 	header["Accept"] = contentMediaType
+	
+	if len(rv.Authorization) > 0 {
+		header["Authorization"] = rv.Authorization
+	}
+	
 	if download {
 		rep.Actions["download"] = &link{Href: rv.DownloadLink(), Header: header}
 	}
@@ -608,6 +614,7 @@ func unpack(r *http.Request) *RequestVars {
 		User: vars["user"],
 		Repo: vars["repo"],
 		Oid:  vars["oid"],
+		Authorization: r.Header.Get("Authorization"),
 	}
 
 	if r.Method == "POST" { // Maybe also check if +json
@@ -640,6 +647,7 @@ func unpackBatch(r *http.Request) *BatchVars {
 	for i := 0; i < len(bv.Objects); i++ {
 		bv.Objects[i].User = vars["user"]
 		bv.Objects[i].Repo = vars["repo"]
+		bv.Objects[i].Authorization = r.Header.Get("Authorization")
 	}
 
 	return &bv


### PR DESCRIPTION
After "Add locks API" (f5f7f0f1f8fc5f5243d7880f5618fd567898e623) the http "Authorization" header field is no longer copied to the metadata json response to go with the url. This broke my usage with git-lfs-authenticate. 

As the removal doesn't look accidental I guess I might be missing something. Looking at the specification it looks like it should be there in the basic version, but I'm not entirely sure about the batched version, maybe the "authenticated" field should be set as well in this case. Either way, with this commit both batched and basic works with the lfs client with git-lfs-authenticate on the server, and it didn't before.

Attached is the json blobs for a meta data request response I captured with master, the last binary release (0.3.0), and with this fix. The response is now identical with the one from 0.3.0 again.

Regards
Markus Ålind

[interface-dumps.txt](https://github.com/git-lfs/lfs-test-server/files/2148610/interface-dumps.txt)
