### PR TITLE
Fix Accept header in verify requests

### DIFF
--- a/mgmt-css.rice-box.go
+++ b/mgmt-css.rice-box.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/GeertJohan/go.rice/embedded"
 	"time"
+
+	"github.com/GeertJohan/go.rice/embedded"
 )
 
 func init() {

--- a/mgmt-templates.rice-box.go
+++ b/mgmt-templates.rice-box.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/GeertJohan/go.rice/embedded"
 	"time"
+
+	"github.com/GeertJohan/go.rice/embedded"
 )
 
 func init() {

--- a/server.go
+++ b/server.go
@@ -19,11 +19,11 @@ import (
 // RequestVars contain variables from the HTTP request. Variables from routing, json body decoding, and
 // some headers are stored.
 type RequestVars struct {
-	Oid      string
-	Size     int64
-	User     string
-	Password string
-	Repo     string
+	Oid           string
+	Size          int64
+	User          string
+	Password      string
+	Repo          string
 	Authorization string
 }
 
@@ -415,7 +415,7 @@ func (a *App) LocksVerifyHandler(w http.ResponseWriter, r *http.Request) {
 		enc.Encode(&VerifiableLockList{Message: err.Error()})
 		return
 	}
-	
+
 	// Limit is optional
 	limit := reqBody.Limit
 	if limit == 0 {
@@ -552,11 +552,11 @@ func (a *App) Represent(rv *RequestVars, meta *MetaObject, download, upload, use
 
 	header := make(map[string]string)
 	header["Accept"] = contentMediaType
-	
+
 	if len(rv.Authorization) > 0 {
 		header["Authorization"] = rv.Authorization
 	}
-	
+
 	if download {
 		rep.Actions["download"] = &link{Href: rv.DownloadLink(), Header: header}
 	}
@@ -611,9 +611,9 @@ func randomLockId() string {
 func unpack(r *http.Request) *RequestVars {
 	vars := mux.Vars(r)
 	rv := &RequestVars{
-		User: vars["user"],
-		Repo: vars["repo"],
-		Oid:  vars["oid"],
+		User:          vars["user"],
+		Repo:          vars["repo"],
+		Oid:           vars["oid"],
 		Authorization: r.Header.Get("Authorization"),
 	}
 

--- a/server.go
+++ b/server.go
@@ -551,10 +551,13 @@ func (a *App) Represent(rv *RequestVars, meta *MetaObject, download, upload, use
 	}
 
 	header := make(map[string]string)
+	verifyHeader := make(map[string]string)
+
 	header["Accept"] = contentMediaType
 
 	if len(rv.Authorization) > 0 {
 		header["Authorization"] = rv.Authorization
+		verifyHeader["Authorization"] = rv.Authorization
 	}
 
 	if download {
@@ -564,7 +567,7 @@ func (a *App) Represent(rv *RequestVars, meta *MetaObject, download, upload, use
 	if upload {
 		rep.Actions["upload"] = &link{Href: rv.UploadLink(useTus), Header: header}
 		if useTus {
-			rep.Actions["verify"] = &link{Href: rv.VerifyLink(), Header: header}
+			rep.Actions["verify"] = &link{Href: rv.VerifyLink(), Header: verifyHeader}
 		}
 	}
 	return rep


### PR DESCRIPTION
The specification says that we need to pass application/vnd.git-lfs+json in the Accept header for verify requests. However, we were telling the client to pass an invalid Accept header with a different MIME type. Since the client should know to pass the proper MIME type, and we don't check the Accept header for verify endpoints, simply avoid telling the client to pass an Accept header at all.

There are no tests for this case because the verify endpoint isn't used unless we use tus.io resumable uploads, and that requires a separate (and optional) project, tusd, so we can't depend on it in the tests.

Fixes #85.
/cc @slonopotamus as reporter