### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ To build from source, use the Go tools:
 Running the binary will start an LFS server on `localhost:8080` by default.
 There are few things that can be configured via environment variables:
 
-	LFS_LISTEN      # The address:port the server listens on, default: "tcp://:8080"
-	LFS_HOST        # The host used when the server generates URLs, default: "localhost:8080"
-	LFS_METADB      # The database file the server uses to store meta information, default: "lfs.db"
-	LFS_CONTENTPATH # The path where LFS files are store, default: "lfs-content"
-	LFS_ADMINUSER   # An administrator username, default: unset
-	LFS_ADMINPASS   # An administrator password, default: unset
-	LFS_CERT        # Certificate file for tls
-	LFS_KEY         # tls key
-	LFS_SCHEME      # set to 'https' to override default http
+    LFS_LISTEN      # The address:port the server listens on, default: "tcp://:8080"
+    LFS_HOST        # The host used when the server generates URLs, default: "localhost:8080"
+    LFS_METADB      # The database file the server uses to store meta information, default: "lfs.db"
+    LFS_CONTENTPATH # The path where LFS files are store, default: "lfs-content"
+    LFS_ADMINUSER   # An administrator username, default: unset
+    LFS_ADMINPASS   # An administrator password, default: unset
+    LFS_CERT        # Certificate file for tls
+    LFS_KEY         # tls key
+    LFS_SCHEME      # set to 'https' to override default http
     LFS_USETUS      # set to 'true' to enable tusd (tus.io) resumable upload server; tusd must be on PATH, installed separately
     LFS_TUSHOST     # The host used to start the tusd upload server, default "localhost:1080"
 
@@ -70,11 +70,11 @@ HTTPS:
 NOTE: If using https with a self signed cert also disable cert checking in the client repo.
 
 ```
-	[lfs]
-		url = "https://localhost:8080/"
+  [lfs]
+    url = "https://localhost:8080/"
 
-	[http]
-		sslverify = false
+  [http]
+    sslverify = false
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ There are few things that can be configured via environment variables:
     LFS_HOST        # The host used when the server generates URLs, default: "localhost:8080"
     LFS_METADB      # The database file the server uses to store meta information, default: "lfs.db"
     LFS_CONTENTPATH # The path where LFS files are store, default: "lfs-content"
-    LFS_ADMINUSER   # An administrator username, default: unset
-    LFS_ADMINPASS   # An administrator password, default: unset
+    LFS_ADMINUSER   # An administrator username, default: not set
+    LFS_ADMINPASS   # An administrator password, default: not set
     LFS_CERT        # Certificate file for tls
     LFS_KEY         # tls key
     LFS_SCHEME      # set to 'https' to override default http
@@ -54,7 +54,10 @@ There are few things that can be configured via environment variables:
 
 If the `LFS_ADMINUSER` and `LFS_ADMINPASS` variables are set, a
 rudimentary admin interface can be accessed via
-`http://$LFS_HOST/mgmt`. Here you can add and remove users.
+`http://$LFS_HOST/mgmt`. Here you can add and remove users, which must
+be done before you can use the server with the client.  If either of
+these variables are not set (which is the default), the administrative
+interface is disabled.
 
 To use the LFS test server with the Git LFS client, configure it in the repository's `.gitconfig` file:
 


### PR DESCRIPTION
Our current description of how to use and access the administrative interface is too terse and confusing.  People are prone to start the server for the first time without any environment variables, which leads to an unusable configuration.

Tell users of the server that they must create users before they can use the server with the client.  Be explicit about what happens if the administrative user and password variable are not set, and try to make it clearer that the default is that they are not set, not the literal string "unset" as a default credential.  The server does not have default credentials, since doing so is not a secure configuration.

In addition, make the indentation consistent across the file using spaces.

/cc @Jazzynupe as reporter
Fixes #87