### PR TITLE
server: accept 64-bit integers in Range headers

### DIFF
--- a/server.go
+++ b/server.go
@@ -240,7 +240,7 @@ func (a *App) GetContentHandler(w http.ResponseWriter, r *http.Request) {
 		match := regex.FindStringSubmatch(rangeHdr)
 		if match != nil && len(match) > 1 {
 			statusCode = 206
-			fromByte, _ = strconv.ParseInt(match[1], 10, 32)
+			fromByte, _ = strconv.ParseInt(match[1], 10, 64)
 			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", fromByte, meta.Size-1, int64(meta.Size)-fromByte))
 		}
 	}


### PR DESCRIPTION
Currently, our code to parse Range headers only handles 32-bit integers. There's no reason this needs to be the case; our code should be fully capable of handling 64-bit integers otherwise, so parse our Range header as a 64-bit number.
