### PR TITLE
Fixed zombie objects creation in Batch API

### DIFF
--- a/server.go
+++ b/server.go
@@ -323,9 +323,21 @@ func (a *App) BatchHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Object is not found
-		meta, err = a.metaStore.Put(object)
-		if err == nil {
-			responseObjects = append(responseObjects, a.Represent(object, meta, meta.Existing, true, useTus))
+		if bv.Operation == "upload" {
+			meta, err = a.metaStore.Put(object)
+			if err == nil {
+				responseObjects = append(responseObjects, a.Represent(object, meta, false, true, useTus))
+			}
+		} else {
+			rep := &Representation{
+				Oid:  object.Oid,
+				Size: object.Size,
+				Error: &ObjectError{
+					Code:    404,
+					Message: "Not found",
+				},
+			}
+			responseObjects = append(responseObjects, rep)
 		}
 	}
 


### PR DESCRIPTION
Was:
1. "upload" response for the first attempt to "download" non-existing object.
2. "download" + "upload" response for any consecutive attempt to "download" non-existing object.

[how-to-reproduce.txt](https://github.com/git-lfs/lfs-test-server/files/4355655/how-to-reproduce.txt)
