### PR TITLE
Update releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
-FROM golang:1.4-onbuild
+FROM golang:1.14.7
 MAINTAINER GitHub, Inc.
+
+WORKDIR /go/src/github.com/git-lfs/lfs-test-server
+
+COPY . .
+
+RUN go build
+
 EXPOSE 8080
+
+CMD /go/src/github.com/git-lfs/lfs-test-server/lfs-test-server

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ sending patches.
 
 ## Installing
 
-Download the [latest version][rel]. It is a single binary file.
-
-Alternatively, use the Go installer:
+Use the Go installer:
 
 ```
   $ go install github.com/github/lfs-test-server


### PR DESCRIPTION
Update the README to no longer point at releases. since they're long obsolete, and refresh the Dockerfile to build easily.