### PR TITLE
Fix tusd arguments

### DIFF
--- a/tus.go
+++ b/tus.go
@@ -45,7 +45,7 @@ func (t *TusServer) Start() {
 		port = hostparts[1]
 	}
 	t.tusProcess = exec.Command("tusd",
-		"-dir", t.dataPath,
+		"-upload-dir", t.dataPath,
 		"-host", host,
 		"-port", port)
 	// Make sure tus server is started before continuing


### PR DESCRIPTION
At some point, tusd changed the flag `-dir` to `-upload-dir`. This PR fixes up lfs-test-server to work with this new format