### PR TITLE
#75 add ExtOrigin config to handle lfs-test-server behind a reverse proxy case

### DIFF
--- a/config.go
+++ b/config.go
@@ -77,12 +77,6 @@ func init() {
 	}
 
 	if Config.ExtOrigin == "" {
-		// why not ignore the IsHTTPS check and use the following statement directly:
-		// `Config.ExtOrigin = fmt.Sprintf("%s://%s", Config.Scheme, Config.Host)`
-		if Config.IsHTTPS() {
-			Config.ExtOrigin = fmt.Sprintf("%s://%s", Config.Scheme, Config.Host)
-		} else {
-			Config.ExtOrigin = fmt.Sprintf("http://%s", Config.Host)
-		}
+		Config.ExtOrigin = fmt.Sprintf("%s://%s", Config.Scheme, Config.Host)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ import (
 type Configuration struct {
 	Listen      string `config:"tcp://:8080"`
 	Host        string `config:"localhost:8080"`
+	ExtOrigin   string `config:""` // consider lfs-test-server may behind a reverse proxy
 	MetaDB      string `config:"lfs.db"`
 	ContentPath string `config:"lfs-content"`
 	AdminUser   string `config:""`
@@ -73,5 +74,15 @@ func init() {
 	if port := os.Getenv("PORT"); port != "" {
 		// If $PORT is set, override LFS_LISTEN. This is useful for deploying to Heroku.
 		Config.Listen = "tcp://:" + port
+	}
+
+	if Config.ExtOrigin == "" {
+		// why not ignore the IsHTTPS check and use the following statement directly:
+		// `Config.ExtOrigin = fmt.Sprintf("%s://%s", Config.Scheme, Config.Host)`
+		if Config.IsHTTPS() {
+			Config.ExtOrigin = fmt.Sprintf("%s://%s", Config.Scheme, Config.Host)
+		} else {
+			Config.ExtOrigin = fmt.Sprintf("http://%s", Config.Host)
+		}
 	}
 }

--- a/mgmt/templates/config.tmpl
+++ b/mgmt/templates/config.tmpl
@@ -5,7 +5,7 @@
   <p><strong>Content:</strong> {{.Config.ContentPath}}</p>
 </div>
 <div class="container">
-  <p>To configure a repository to use this LFS server, add the following to the repository's <code>.lfsconfig</code> file:</p>
+  <p>To configure a repository to use this LFS server, add the following to the repository's Git config or <code>.lfsconfig</code> file:</p>
   <pre>
 <code>[lfs]
     url = "{{.Config.ExtOrigin}}"

--- a/mgmt/templates/config.tmpl
+++ b/mgmt/templates/config.tmpl
@@ -1,14 +1,14 @@
 <div class="container">
-  <p><strong>URL:</strong> {{.Config.Scheme}}://{{.Config.Host}}</p>
+  <p><strong>URL:</strong> {{.Config.ExtOrigin}}</p>
   <p><strong>Listen Address:</strong> {{.Config.Listen}}</p>
   <p><strong>Database:</strong> {{.Config.MetaDB}}</p>
   <p><strong>Content:</strong> {{.Config.ContentPath}}</p>
 </div>
 <div class="container">
-  <p>To configure a repository to use this LFS server, add the following to the repository's <code>.gitconfig</code> file:</p>
+  <p>To configure a repository to use this LFS server, add the following to the repository's <code>.lfsconfig</code> file:</p>
   <pre>
 <code>[lfs]
-    url = "{{.Config.Scheme}}://{{.Config.Host}}/"
+    url = "{{.Config.ExtOrigin}}"
 </code>
 </pre>
 

--- a/server.go
+++ b/server.go
@@ -131,11 +131,7 @@ func (v *RequestVars) internalLink(subpath string) string {
 
 	path += fmt.Sprintf("/%s/%s", subpath, v.Oid)
 
-	if Config.IsHTTPS() {
-		return fmt.Sprintf("%s://%s%s", Config.Scheme, Config.Host, path)
-	}
-
-	return fmt.Sprintf("http://%s%s", Config.Host, path)
+	return fmt.Sprintf("%s%s", Config.ExtOrigin, path)
 }
 
 func (v *RequestVars) tusLink() string {
@@ -149,11 +145,7 @@ func (v *RequestVars) tusLink() string {
 func (v *RequestVars) VerifyLink() string {
 	path := fmt.Sprintf("/verify/%s", v.Oid)
 
-	if Config.IsHTTPS() {
-		return fmt.Sprintf("%s://%s%s", Config.Scheme, Config.Host, path)
-	}
-
-	return fmt.Sprintf("http://%s%s", Config.Host, path)
+	return fmt.Sprintf("%s%s", Config.ExtOrigin, path)
 }
 
 // link provides a structure used to build a hypermedia representation of an HTTP link.


### PR DESCRIPTION
As described in #75, when the `lfs-test-server` is behind a reverse proxy, the `LFS_HOST` will not denote the external link correctly. For example, the external link is `https://git-lfs.example.com` served by `nginx`, the `LFS_LISTEN` is `tcp://localhost:1234` and `LFS_SCHEME` is `http`. Whatever `LFS_HOST` is set, the external URL is incorrect.
I added additional config, i.e., `LFS_EXTORIGIN`, which is blank by default. If it is blank, the old method will be used to denote the external origin, as follows:
```golang
if Config.IsHTTPS() {
	Config.ExtOrigin = fmt.Sprintf("%s://%s", Config.Scheme, Config.Host)
} else {
	Config.ExtOrigin = fmt.Sprintf("http://%s", Config.Host)
}
```
However, when the user set `LFS_EXTORIGIN`, it will be used to skip the old setting, e.g., `LFS_EXTORIGIN='https://git-lfs.example.com'`. 

By the way, why not use `Config.ExtOrigin = fmt.Sprintf("%s://%s", Config.Scheme, Config.Host)` to replace the above old external link generation method?