### PR TITLE
Move to go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.14.7
-MAINTAINER GitHub, Inc.
+FROM golang:1.20
+LABEL org.opencontainers.image.authors=" GitHub, Inc."
 
 WORKDIR /go/src/github.com/git-lfs/lfs-test-server
 

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,4 @@ require (
 	github.com/gorilla/mux v0.0.0-20140926153814-e444e69cbd2e
 )
 
-go 1.16
+go 1.20


### PR DESCRIPTION
At least 1.18 is required to build the current source, to support the file embedding.

1.16 is the earliest with the feature, but the all:mgmt pattern doesn't work until 1.18.

(I might also suggest adding a Docker build of at least one platform to the release script. It would catch issues like this).
