### PR TITLE
cmdline: add basic cmdline interface to at least look up objects by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,21 @@ Check the managment page
 browser: https://localhost:9999/mgmt
 
 
+## Debugging
+
+`lfs-test-server` supports a basic cmd to lookup `OID's` via the cmdline to help in debugging, eg. investigating client problems with a particular `OID` and it's properties.
+In this mode `lfs-test-server` expects the same configuration as when running in daemon mode, but will just executing the requested cmd and then exit.
+
+This is especially helpful in server environments where it's not always possible to get to the web interface easily or where it's just too slow because of DB size.
+
+`lfs-test-server cmd <OID>`
+
+Outputs the full OID record
+
+# Example
+
+```
+% . /etc/default/lfs-instancefoo    # to source server config
+% ./lfs-test-server cmd 7c9414fe21ad7b45ffb6e72da86f9a9e13dbb2971365ae7bcb8cc7fbbba7419c
+&{Oid:7c9414fe21ad7b45ffb6e72da86f9a9e13dbb2971365ae7bcb8cc7fbbba7419c Size:3334144 Existing:false}
+```

--- a/main.go
+++ b/main.go
@@ -63,9 +63,28 @@ func wrapHttps(l net.Listener, cert, key string) (net.Listener, error) {
 	return tlsListener, nil
 }
 
+func maincmd() {
+	// cmdline interface: cmd oid -> returns object from db or error
+	metaStore, err := NewMetaStore(Config.MetaDB)
+	if err != nil {
+		logger.Fatal(kv{"fn": "maincmd", "err": "Could not open the meta store: " + err.Error()})
+	}
+
+	oid := os.Args[2]
+	meta, err := metaStore.UnsafeGet(&RequestVars{Oid: oid})
+	if err != nil {
+		logger.Fatal(kv{"fn": "maincmd", "err": "Could not find object: " + err.Error()})
+	}
+	fmt.Printf("%+v\n", meta)
+}
+
 func main() {
 	if len(os.Args) == 2 && os.Args[1] == "-v" {
 		fmt.Println(version)
+		os.Exit(0)
+	}
+	if len(os.Args) > 2 && os.Args[1] == "cmd" {
+		maincmd()
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
we needed some way to quickly inspect boltdb for some oid's, and added some very hacky cmdline interface to look them up.

it's really only a quick hack, but nice to not need a browser and additional accesses that might not be available in prod.

example usage:
```
% . /etc/default/lfs-foo    # to source all variables from prod instance
% ./lfs-test-server cmd 7c9414fe21ad7b45ffb6e72da86f9a9e13dbb2971365ae7bcb8cc7fbbba7419c
&{Oid:7c9414fe21ad7b45ffb6e72da86f9a9e13dbb2971365ae7bcb8cc7fbbba7419c Size:3334144 Existing:false}
```